### PR TITLE
feat: refactor so chat logs are split by appointment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import {
   createBrowserRouter,
   RouterProvider,
 } from "react-router-dom";
+import PostAppointmentReview from "./pages/patientDashboard/PostAppointment";
 
 const router = createBrowserRouter([
   {
@@ -44,6 +45,10 @@ const router = createBrowserRouter([
     path: "/post-appointment",
     element: <PostAppointmentPage />,
   },
+  {
+    path: "/patient-post-appointment",
+    element: <PostAppointmentReview/>
+  }
 ]);
 
 const root = ReactDOM.createRoot(document.getElementById('root'));

--- a/src/pages/doctorDashboard/doctorDashboard.js
+++ b/src/pages/doctorDashboard/doctorDashboard.js
@@ -108,8 +108,9 @@ function DoctorDashboard() {
                 body: JSON.stringify({
                     doctor_id: doctorDetails.doctor_id,
                     patient_id: activeChatAppointment.patient_id,
+                    appointment_id: apptId,
                     sender_type: 'doctor',
-                    message: 'The appointment has ended.',
+                    message: '__APPOINTMENT_ENDED__',
                 }),
             });
 
@@ -199,6 +200,7 @@ function DoctorDashboard() {
                         <ChatWindow
                             doctorId={doctorDetails.doctor_id}
                             patientId={activeChatAppointment.patient_id}
+                            appointmentId={activeChatAppointment.appointment_id}
                             isDoctor={true}
                         />
                     </div>

--- a/src/pages/patientDashboard/PostAppointment.css
+++ b/src/pages/patientDashboard/PostAppointment.css
@@ -1,0 +1,73 @@
+.review-page {
+    background-color: #f5f7fa;
+    min-height: 100vh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+}
+
+.review-card {
+    background: #ffffff;
+    border-radius: 8px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+    max-width: 400px;
+    width: 100%;
+    padding: 2rem;
+}
+
+.review-title {
+    margin: 0 0 1.5rem;
+    font-size: 1.75rem;
+    text-align: center;
+    color: #333;
+}
+
+.review-form .form-group {
+    margin-bottom: 1.25rem;
+    display: flex;
+    flex-direction: column;
+}
+
+.review-form .form-group label {
+    margin-bottom: 0.5rem;
+    font-weight: 600;
+    color: #555;
+}
+
+.review-form .form-group input,
+.review-form .form-group textarea {
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    font-size: 1rem;
+    color: #333;
+}
+
+.review-form .form-group input:focus,
+.review-form .form-group textarea:focus {
+    outline: none;
+    border-color: #007bff;
+}
+
+.submit-button {
+    width: 100%;
+    padding: 0.75rem;
+    background-color: #007bff;
+    border: none;
+    border-radius: 4px;
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.submit-button:disabled {
+    background-color: #a0c4ff;
+    cursor: not-allowed;
+}
+
+.submit-button:not(:disabled):hover {
+    background-color: #0056b3;
+}

--- a/src/pages/patientDashboard/PostAppointment.js
+++ b/src/pages/patientDashboard/PostAppointment.js
@@ -1,0 +1,60 @@
+// src/pages/PostAppointmentReview.jsx
+import React, { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+
+export default function PostAppointmentReview() {
+    const navigate = useNavigate();
+    const { appointment_id, doctor_id, patient_id } = useLocation().state || {};
+    const [rating, setRating] = useState(5);
+    const [review, setReview]   = useState('');
+    const [submitting, setSubmitting] = useState(false);
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+        setSubmitting(true);
+        const res = await fetch('/api/ratings/rate_doctor', {
+            method: 'POST',
+            headers: {'Content-Type':'application/json'},
+            body: JSON.stringify({ patient_id, doctor_id, appointment_id, rating, review })
+        });
+        if (res.ok) {
+            alert('Thanks for your feedback!');
+            navigate('/patient');   // or wherever your patient dashboard lives
+        } else {
+            const err = await res.json();
+            alert('Error: ' + (err.error||'Unknown'));
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <div style={{ padding: '2rem', maxWidth: 400, margin: '0 auto' }}>
+            <h2>Rate Your Appointment</h2>
+            <form onSubmit={handleSubmit}>
+                <label>
+                    Rating (0–5):
+                    <input
+                        type="number"
+                        min="0" max="5" step="0.5"
+                        value={rating}
+                        onChange={e => setRating(e.target.value)}
+                        required
+                    />
+                </label>
+                <br/><br/>
+                <label>
+                    Review (optional):
+                    <textarea
+                        rows={4}
+                        value={review}
+                        onChange={e => setReview(e.target.value)}
+                    />
+                </label>
+                <br/><br/>
+                <button type="submit" disabled={submitting}>
+                    {submitting ? 'Submitting…' : 'Submit Feedback'}
+                </button>
+            </form>
+        </div>
+    );
+}

--- a/src/pages/patientDashboard/PostAppointment.js
+++ b/src/pages/patientDashboard/PostAppointment.js
@@ -1,12 +1,13 @@
-// src/pages/PostAppointmentReview.jsx
 import React, { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
+import './PostAppointment.css';
 
 export default function PostAppointmentReview() {
     const navigate = useNavigate();
     const { appointment_id, doctor_id, patient_id } = useLocation().state || {};
-    const [rating, setRating] = useState(5);
-    const [review, setReview]   = useState('');
+
+    const [rating, setRating]         = useState(5);
+    const [review, setReview]         = useState('');
     const [submitting, setSubmitting] = useState(false);
 
     const handleSubmit = async (e) => {
@@ -17,20 +18,22 @@ export default function PostAppointmentReview() {
             patient_id,
             doctor_id,
             appointment_id,
-            rating: parseFloat(rating),  // now guaranteed to be a number
+            rating: parseFloat(rating),
             review
         };
 
-        console.log('⏩ POST rate_doctor payload:', payload);
+        const res = await fetch(
+            'http://localhost:5000/api/post-appointment/ratings/rate_doctor',
+            {
+                method: 'POST',
+                headers: { 'Content-Type':'application/json' },
+                body: JSON.stringify(payload)
+            }
+        );
 
-        const res = await fetch('http://localhost:5000/api/post-appointment/ratings/rate_doctor', {
-            method: 'POST',
-            headers: {'Content-Type':'application/json'},
-            body: JSON.stringify({ patient_id, doctor_id, appointment_id, rating, review })
-        });
         if (res.ok) {
             alert('Thanks for your feedback!');
-            navigate('/patient');   // or wherever your patient dashboard lives
+            navigate('/patient');
         } else {
             const err = await res.json();
             alert('Error: ' + (err.error||'Unknown'));
@@ -39,33 +42,42 @@ export default function PostAppointmentReview() {
     };
 
     return (
-        <div style={{ padding: '2rem', maxWidth: 400, margin: '0 auto' }}>
-            <h2>Rate Your Appointment</h2>
-            <form onSubmit={handleSubmit}>
-                <label>
-                    Rating (0–5):
-                    <input
-                        type="number"
-                        min="0" max="5" step="0.5"
-                        value={rating}
-                        onChange={e => setRating(e.target.value)}
-                        required
-                    />
-                </label>
-                <br/><br/>
-                <label>
-                    Review (optional):
-                    <textarea
-                        rows={4}
-                        value={review}
-                        onChange={e => setReview(e.target.value)}
-                    />
-                </label>
-                <br/><br/>
-                <button type="submit" disabled={submitting}>
-                    {submitting ? 'Submitting…' : 'Submit Feedback'}
-                </button>
-            </form>
+        <div className="review-page">
+            <div className="review-card">
+                <h2 className="review-title">Rate Your Appointment</h2>
+
+                <form className="review-form" onSubmit={handleSubmit}>
+                    <div className="form-group">
+                        <label>Rating (0–5)</label>
+                        <input
+                            type="number"
+                            min="0"
+                            max="5"
+                            step="0.5"
+                            value={rating}
+                            onChange={e => setRating(e.target.value)}
+                            required
+                        />
+                    </div>
+
+                    <div className="form-group">
+                        <label>Review (optional)</label>
+                        <textarea
+                            rows="4"
+                            value={review}
+                            onChange={e => setReview(e.target.value)}
+                        />
+                    </div>
+
+                    <button
+                        type="submit"
+                        className="submit-button"
+                        disabled={submitting}
+                    >
+                        {submitting ? 'Submitting…' : 'Submit Feedback'}
+                    </button>
+                </form>
+            </div>
         </div>
     );
 }

--- a/src/pages/patientDashboard/PostAppointment.js
+++ b/src/pages/patientDashboard/PostAppointment.js
@@ -12,7 +12,18 @@ export default function PostAppointmentReview() {
     const handleSubmit = async (e) => {
         e.preventDefault();
         setSubmitting(true);
-        const res = await fetch('/api/ratings/rate_doctor', {
+
+        const payload = {
+            patient_id,
+            doctor_id,
+            appointment_id,
+            rating: parseFloat(rating),  // now guaranteed to be a number
+            review
+        };
+
+        console.log('⏩ POST rate_doctor payload:', payload);
+
+        const res = await fetch('http://localhost:5000/api/post-appointment/ratings/rate_doctor', {
             method: 'POST',
             headers: {'Content-Type':'application/json'},
             body: JSON.stringify({ patient_id, doctor_id, appointment_id, rating, review })

--- a/src/pages/patientDashboard/patientDashboard.js
+++ b/src/pages/patientDashboard/patientDashboard.js
@@ -307,6 +307,8 @@ function PatientDashboard() {
                         <ChatWindow
                             doctorId={activeChatAppointment.doctor_id}
                             patientId={patientDetails.patient_id}
+                            appointmentId={activeChatAppointment.appointment_id}
+                            isDoctor={false}
                         />
                     </div>
                 );


### PR DESCRIPTION
## Changes Made
<!-- Briefly describe what you changed and why -->
Our database Frontend and Backend did not support splitting up chat logs by appointment. When trying to allow a Patient to leave a review post appointment, the prior statment became an issue. I did a decent amount of refactoring so that appointments are split up separate from each other.

## Testing Done
<!-- Outline how you tested your changes, including any manual steps or automated tests -->

## Does Anyone Else Need to Know About This Change?
<!-- Tag team members, mention documentation updates, or call out dependencies if applicable -->
- [ ] #daily-updates on discord